### PR TITLE
Support for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^2.10",
-        "illuminate/contracts": "^9.0",
+        "illuminate/contracts": "^9.0|^10.0",
         "kalnoy/nestedset": "^6.0.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },


### PR DESCRIPTION
This PR adds support for illuminate/contracts ^10.0 which is needed to support Laravel 10 and above.